### PR TITLE
No need to prank when withdraw

### DIFF
--- a/audit-data/auditTests/ProofOfCodes.t.sol
+++ b/audit-data/auditTests/ProofOfCodes.t.sol
@@ -77,7 +77,6 @@ contract ProofOfCodes is PuppyRaffleTest {
         assert(endingTotalFees < startingTotalFees);
 
         // We are also unable to withdraw any fees because of the require check
-        vm.prank(puppyRaffle.feeAddress());
         vm.expectRevert("PuppyRaffle: There are currently players active!");
         puppyRaffle.withdrawFees();
     }


### PR DESCRIPTION
There are no access controls on who can execute a withdraw as far as the requirement are met