### PR TITLE
Fixes the make install error caused by an incompatible version of forge-std

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean  :; forge clean
 # Remove modules
 remove :; rm -rf .gitmodules && rm -rf .git/modules/* && rm -rf lib && touch .gitmodules && git add . && git commit -m "modules"
 
-install :; forge install foundry-rs/forge-std && forge install openzeppelin/openzeppelin-contracts@v3.4.0 && forge install Brechtpd/base64
+install :; forge install foundry-rs/forge-std@v1.3.0 && forge install openzeppelin/openzeppelin-contracts@v3.4.0 && forge install Brechtpd/base64
 
 # Update Dependencies
 update:; forge update


### PR DESCRIPTION
#### Problem
The PuppyRaffle contract uses pragma solidity ^0.7.6, but the latest versions of foundry-rs/forge-std require Solidity >= 0.8.13. Running `make` pulls the latest forge-std, resulting in compilation errors.

#### Solution
Pin forge-std to version v1.3.0, which supports Solidity >= 0.6.2.