### PR TITLE
Remove unnecessary commits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all: remove install build
 clean  :; forge clean
 
 # Remove modules
-remove :; rm -rf .gitmodules && rm -rf .git/modules/* && rm -rf lib && touch .gitmodules && git add . && git commit -m "modules"
+remove :; rm -rf .gitmodules && rm -rf .git/modules/* && rm -rf lib && touch .gitmodules
 
 install :; forge install foundry-rs/forge-std@v1.3.0 && forge install openzeppelin/openzeppelin-contracts@v3.4.0 && forge install Brechtpd/base64
 


### PR DESCRIPTION
`make remove` or cleanup targets should not modify the repository’s commit history without explicit user intent. Users may want to remove modules locally without immediately committing the change.

Repeatedly running `make` or `make remove` could clutter the Git history unintentionally with unclear commit message "modules".