### PR TITLE
[Draft] Remove auto-commit from make remove?

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all: remove install build
 clean  :; forge clean
 
 # Remove modules
-remove :; rm -rf .gitmodules && rm -rf .git/modules/* && rm -rf lib && touch .gitmodules && git add . && git commit -m "modules"
+remove :; rm -rf .gitmodules && rm -rf .git/modules/* && rm -rf lib && touch .gitmodules
 
 install :; forge install foundry-rs/forge-std@v1.3.0 && forge install openzeppelin/openzeppelin-contracts@v3.4.0 && forge install Brechtpd/base64
 


### PR DESCRIPTION
### PR Intention
Removes `git add . && git commit -m "modules"` from the `make remove` target.

### Uncertainty
- Unsure if the original behaviour was intentional or a workaround for something. 
- Looking for feedback on whether this change is desired or if there’s a reason to keep the commit.

### Current behaviour
- `make remove` deletes modules and commits the removal with message `"modules"`.
- Repeatedly running `make remove` through `make` could clutter Git history with unclear commit messages.

### Proposed behavior
- `make remove` only deletes library files (`.gitmodules`, `.git/modules/*`, `lib/`).
- The target does **not** modify the repository’s commit history. Users can still run `git add . && git commit` manually if they want to record the removal.

### Questions
- Was the auto-commit added to satisfy some tooling or script?